### PR TITLE
Update reat-base-table to latest verison for React 17 support

### DIFF
--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -64,15 +64,15 @@
     "@fluidframework/tinylicious-driver": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "@fluidframework/view-interfaces": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "@hig/fonts": "^1.0.2",
-    "@material-ui/core": "^4.0.0",
-    "@material-ui/lab": "^4.0.0-alpha.16",
-    "@material-ui/styles": "^4.1.1",
+    "@material-ui/core": "4.12.4",
+    "@material-ui/lab": "4.0.0-alpha.61",
+    "@material-ui/styles": "4.11.5",
     "@types/uuid": "^8.3.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-virtualized-auto-sizer": "^1.0.2"
+    "react-virtualized-auto-sizer": "^1.0.6"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -38,17 +38,17 @@
   },
   "dependencies": {
     "@hig/fonts": "^1.0.2",
-    "@material-ui/core": "^4.0.0",
-    "@material-ui/lab": "^4.0.0-alpha.16",
-    "@material-ui/styles": "^4.1.1",
+    "@material-ui/core": "4.12.4",
+    "@material-ui/lab": "4.0.0-alpha.61",
+    "@material-ui/styles": "4.11.5",
     "base64-js": "1.3.0",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "lodash.debounce": "^4.0.8",
     "memoize-one": "^5.0.0",
-    "react-base-table": "1.0.2",
-    "react-loading-skeleton": "^1.1.2",
+    "react-base-table": "1.13.2",
+    "react-loading-skeleton": "^3.1.0",
     "react-select": "^2.4.3",
-    "react-virtualized-auto-sizer": "^1.0.2"
+    "react-virtualized-auto-sizer": "^1.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -167,7 +167,7 @@ const styles = (theme: Theme) => createStyles({
  */
 const themedSkeleton = (inSkeleton: JSX.Element) => {
   return (
-    <SkeletonTheme color="#C4C4C4">
+    <SkeletonTheme baseColor="#C4C4C4">
       {inSkeleton}
     </SkeletonTheme>
   );
@@ -472,7 +472,7 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
         Object.keys(rest).length === 0 ? null : themedSkeleton(circleSkeleton);
       const components = this.props.checkoutInProgress ? { ExpandIcon: skeletonExpandIcon } : {};
       const fakeRows = Array.from(Array(getRandomRowsNum()), (x, i) => ({ id: i.toString() }));
-      const rowsData = this.props.checkoutInProgress ? fakeRows : rows;
+      const rowsData = this.props.checkoutInProgress ? fakeRows as any : rows;
       this.columns = this.generateColumns(width);
       const getHeader = ({ cells, headerIndex }) => {
         if (headerIndex === 1) {
@@ -922,8 +922,8 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
      * Maps the expanded row to either the filteredExpanded list or the whole dataset expanded list. This
      * allows the user to come back to the state before performing the filtering
      */
-    // eslint-disable-next-line max-len
-    private readonly handleRowExpanded = ({ rowData, expanded: newExpandedFlag }: { rowData: IInspectorRow; expanded: boolean; }) => {
+    private readonly handleRowExpanded = ({ expanded: newExpandedFlag, rowData }:
+       { expanded: boolean; rowData: IInspectorRow; }) => {
       const newExpanded = { ...this.state.expanded };
       const idInExpanded = rowData.id in newExpanded;
       if (newExpandedFlag && !idInExpanded) {
@@ -982,7 +982,7 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
       // With the new table it may not need force render if the
       // right events handlers are used.
       this.table.current.columnManager.resetCache();
-      this.table.current.forceUpdateTable();
+      this.table.current.forceUpdate();
     };
   }
 

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -40,7 +40,14 @@ import { Utils } from "./typeUtils";
 import { expandAll, fillExpanded, getReferenceValue, IInspectorSearchControls, isPrimitive, search, showNextResult,
   toTableRows } from "./utils";
 
-const defaultSort = { key: "name", order: SortOrder.ASC };
+// @TODO Figure out why SortOrder is not resolved as value after
+// updating the table version.
+enum TableSortOrder {
+  ASC = "asc",
+  DSC = "dsc",
+}
+
+const defaultSort = { key: "name", order: TableSortOrder.ASC } as { key: React.Key; order: SortOrder; };
 
 const footerHeight = 32;
 
@@ -265,15 +272,18 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
     private readonly dataCreation: boolean;
     private columns: any;
     private readonly debouncedSearchChange: (searchExpression: string) => void;
-    private readonly table = React.createRef();
+    private readonly table;
     private toTableRowOptions;
 
     public constructor(props) {
       super(props);
+
+      this.table = React.createRef<BaseTable>();
+
       const { followReferences } = props;
       this.dataCreation = !!this.props.dataCreationHandler && !!this.props.dataCreationOptionGenerationHandler;
       this.columns = this.generateColumns(props.width);
-      this.toTableRowOptions = { addDummy: true, ascending: defaultSort.order === SortOrder.ASC,
+      this.toTableRowOptions = { addDummy: true, ascending: defaultSort.order === TableSortOrder.ASC,
         depth: 0, followReferences };
 
       this.debouncedSearchChange = debounce((searchExpression: string) => {
@@ -968,7 +978,11 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
     };
 
     private readonly forceUpdateBaseTable = () => {
-      (this.table.current as any).table.bodyRef.recomputeGridSize();
+      // @TODO Revisit this logic.
+      // With the new table it may not need force render if the
+      // right events handlers are used.
+      this.table.current.columnManager.resetCache();
+      this.table.current.forceUpdateTable();
     };
   }
 

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
@@ -5,6 +5,7 @@
 
 import { BaseProxifiedProperty } from "@fluid-experimental/property-proxy";
 import { BaseProperty } from "@fluid-experimental/property-properties";
+import { SortOrder } from "react-base-table";
 import { IRepoExpiryGetter, IRepoExpirySetter } from "./CommonTypes";
 import { IInspectorSearchState } from "./utils";
 
@@ -203,6 +204,9 @@ export interface IInspectorTableState {
   searchInProgress: boolean;
   searchState?: IInspectorSearchState;
   showFormRowID: string;
-  sortBy: { [key: string]: string; };
+  sortBy: {
+    key: React.Key;
+    order: SortOrder;
+  };
   tableRows: IInspectorRow[];
 }

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1682,48 +1682,11 @@
 					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
 					"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
 				},
-				"@emotion/memoize": {
-					"version": "0.6.6",
-					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-					"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-				},
-				"@emotion/serialize": {
-					"version": "0.9.1",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-					"integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
-					"requires": {
-						"@emotion/hash": "^0.6.6",
-						"@emotion/memoize": "^0.6.6",
-						"@emotion/unitless": "^0.6.7",
-						"@emotion/utils": "^0.8.2"
-					}
-				},
-				"@emotion/unitless": {
-					"version": "0.6.7",
-					"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-					"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
-				},
-				"@emotion/utils": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-					"integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
-				},
 				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+					"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
 				}
-			}
-		},
-		"@emotion/cache": {
-			"version": "10.0.29",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-			"requires": {
-				"@emotion/sheet": "0.9.4",
-				"@emotion/stylis": "0.8.5",
-				"@emotion/utils": "0.11.3",
-				"@emotion/weak-memoize": "0.2.5"
 			}
 		},
 		"@emotion/hash": {
@@ -1732,46 +1695,42 @@
 			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
 		},
 		"@emotion/memoize": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
 		},
 		"@emotion/serialize": {
-			"version": "0.11.16",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+			"integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
 			"requires": {
-				"@emotion/hash": "0.8.0",
-				"@emotion/memoize": "0.7.4",
-				"@emotion/unitless": "0.7.5",
-				"@emotion/utils": "0.11.3",
-				"csstype": "^2.5.7"
+				"@emotion/hash": "^0.6.6",
+				"@emotion/memoize": "^0.6.6",
+				"@emotion/unitless": "^0.6.7",
+				"@emotion/utils": "^0.8.2"
+			},
+			"dependencies": {
+				"@emotion/hash": {
+					"version": "0.6.6",
+					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+					"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+				}
 			}
 		},
-		"@emotion/sheet": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-		},
 		"@emotion/stylis": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+			"integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
 		},
 		"@emotion/unitless": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+			"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
 		},
 		"@emotion/utils": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-		},
-		"@emotion/weak-memoize": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+			"integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
 		},
 		"@endemolshinegroup/cosmiconfig-typescript-loader": {
 			"version": "3.0.2",
@@ -2236,32 +2195,32 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.1.tgz",
-			"integrity": "sha512-uQka9Pl/A5kHW+Q8aP6DLO+Sl9LSt0E88UNvLPgK0wLchHdfFhFgaFsLkaWGZDERk1kTsiKFkYOHzTlLqyJbzA==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.2.tgz",
+			"integrity": "sha512-qsYPUYMkBsVHY5X2g0nzmSL+3A7rl+NUEr7VIjOfZ6dlqMrwm5uKYOzgtVlokwBxpmLBn2kpN7kMTwWgyfO7eQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/local-driver": "^1.2.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
-				"@fluidframework/odsp-driver": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/local-driver": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-driver": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
-				"@fluidframework/tool-utils": "^1.2.1",
-				"@fluidframework/view-adapters": "^1.2.1",
-				"@fluidframework/view-interfaces": "^1.2.1",
-				"@fluidframework/web-code-loader": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/tool-utils": "^1.2.2",
+				"@fluidframework/view-adapters": "^1.2.2",
+				"@fluidframework/view-interfaces": "^1.2.2",
+				"@fluidframework/web-code-loader": "^1.2.2",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2457,25 +2416,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.1.tgz",
-			"integrity": "sha512-UvakWsTakNiXPJbAwYO3hsYDbo02yITZPLH+eEkmQkynP0WFRvE6CItEadXtYg2jhCIfHJIj6OBd6oTMlHFhsA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.2.tgz",
+			"integrity": "sha512-ioDJLk6clNMSbACdC1cl1ujnnyrtO2pUpmaJcGXoNUHruUFeAL4crcSbQ8a6IAtbu0SsoxBxY1yPZSEFRtNUcw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
-				"@fluidframework/request-handler": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/synthesize": "^1.2.1",
-				"@fluidframework/view-interfaces": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/request-handler": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/synthesize": "^1.2.2",
+				"@fluidframework/view-interfaces": "^1.2.2",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -2599,17 +2558,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.1.tgz",
-			"integrity": "sha512-7Zn7Eb0ZOr8TVLI0SRcyyXBDjECQwFFaHoOmOl7r/Q/TYzsL37sDg075spu3ltKirIxnRUvMJ1g1Y8gbctvqag==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.2.tgz",
+			"integrity": "sha512-52NxCVz8Eys833hBuS3YIaCPNPdfuJwUv6ajxzpGQLjODFXlKJCA2daKJDZcObsOz4ECHXzVs5NmAcCK1uswWA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -2672,13 +2631,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.1.tgz",
-			"integrity": "sha512-v5IGtw1Vvc431gZYmXuWHDRtN7lXVoOfExzkqAO0GvLwYq35XnX4pNyqtH/kX5sC307032qR5obUR5t2zX6Izw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.2.tgz",
+			"integrity": "sha512-AgIfFFbjZu/vwcDOiD253pu1HOLBwrg3AVcEIp0tXfkAKe4De5aYkPsZ1dq1fVWsd4/VR38n6vNdPQYB+QJSJg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2714,20 +2673,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.1.tgz",
-			"integrity": "sha512-loWcHga/+R3OKNBaS0/jy6nCkiidvgWNFcDElT0GOaOdf1WljKBkLqTuOsrXVzbiuDymd1Fe/L47KaeVlho+eA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.2.tgz",
+			"integrity": "sha512-NEBj6IZQMXiurwWdRr/4z5oxHAVGwrLxK7Anru3WsJi17D9e/WJfY23qsCedVbVAU5EbhoQ3LAAzcwlAa4WCYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2761,20 +2720,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.1.tgz",
-			"integrity": "sha512-loWcHga/+R3OKNBaS0/jy6nCkiidvgWNFcDElT0GOaOdf1WljKBkLqTuOsrXVzbiuDymd1Fe/L47KaeVlho+eA==",
+			"version": "npm:@fluidframework/container-loader@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.2.tgz",
+			"integrity": "sha512-NEBj6IZQMXiurwWdRr/4z5oxHAVGwrLxK7Anru3WsJi17D9e/WJfY23qsCedVbVAU5EbhoQ3LAAzcwlAa4WCYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2808,25 +2767,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.1.tgz",
-			"integrity": "sha512-64BVZEaG5RftaqblMsVXqLiveaUI5pZ6nTo2cHLmJH8zi56geH8O+EUYmrMlGswqgpjTCfIGTkrkisvJVeO2Dw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.2.tgz",
+			"integrity": "sha512-wlB7wVVYU/If+rGX3Cr6wN8oI0edUcezVAVnx08H6/fcoSjBQG9VziypazQVHuHrbjLSmGS18SVn5lBYB5plDQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2858,16 +2817,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.1.tgz",
-			"integrity": "sha512-bzwyjIkxGKZYwFwLkl6icbMpPFONP6uIpnPTKrmk7Js6rNK66CbaIKMHfFgGw6G4hn624zXWbNwqZC17UkEBAQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.2.tgz",
+			"integrity": "sha512-0GA6FlDV87dPRL515hJfIUFf2eANSeVJfWyJHsXwe+QFUEknadpnfaOJDBwO0MG92/IG2sJJvr3X4aXRZ0q2fA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2882,16 +2841,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.1.tgz",
-			"integrity": "sha512-bzwyjIkxGKZYwFwLkl6icbMpPFONP6uIpnPTKrmk7Js6rNK66CbaIKMHfFgGw6G4hn624zXWbNwqZC17UkEBAQ==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.2.tgz",
+			"integrity": "sha512-0GA6FlDV87dPRL515hJfIUFf2eANSeVJfWyJHsXwe+QFUEknadpnfaOJDBwO0MG92/IG2sJJvr3X4aXRZ0q2fA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2906,25 +2865,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.1.tgz",
-			"integrity": "sha512-64BVZEaG5RftaqblMsVXqLiveaUI5pZ6nTo2cHLmJH8zi56geH8O+EUYmrMlGswqgpjTCfIGTkrkisvJVeO2Dw==",
+			"version": "npm:@fluidframework/container-runtime@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.2.tgz",
+			"integrity": "sha512-wlB7wVVYU/If+rGX3Cr6wN8oI0edUcezVAVnx08H6/fcoSjBQG9VziypazQVHuHrbjLSmGS18SVn5lBYB5plDQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2956,15 +2915,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.1.tgz",
-			"integrity": "sha512-IiTVL0yVq9Skol7CEQ5pCxeReNiHOndKIJApx3VvqifdHnbW1+P7AcbJUEGnnezXvERgRVZ3RrYUdMhHBaasnw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.2.tgz",
+			"integrity": "sha512-17oz+f3H4JGKU+E7qY6gzdNKAr2mNXZAFiXhvTErfi91SuftKY71c+a+J1MACngZdJzolws7BCt2w07+gjXLDw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -2978,15 +2937,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.1.tgz",
-			"integrity": "sha512-IiTVL0yVq9Skol7CEQ5pCxeReNiHOndKIJApx3VvqifdHnbW1+P7AcbJUEGnnezXvERgRVZ3RrYUdMhHBaasnw==",
+			"version": "npm:@fluidframework/container-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.2.tgz",
+			"integrity": "sha512-17oz+f3H4JGKU+E7qY6gzdNKAr2mNXZAFiXhvTErfi91SuftKY71c+a+J1MACngZdJzolws7BCt2w07+gjXLDw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3000,9 +2959,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.1.tgz",
-			"integrity": "sha512-s6vP8rPHxd7APaLAkj1G2xjtOv2tczyFnnD7B0VlFUaeMO8aeEegtwgo2l3f2OSmt2alY5hQxLRiOkeLmPrjCA=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.2.tgz",
+			"integrity": "sha512-LSsJksyj7go20lmCJPgepj3hEOi5S62OHChy9ZkhH6U9e/bteBtz8vrNGS/IXiCpK2zxPsr7HEa9PdVsw6etlQ=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@1.1.0",
@@ -3010,17 +2969,17 @@
 			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.1.tgz",
-			"integrity": "sha512-hs79CmcmkWWg+INCZ2mGc/BeeyhXth/q2Yt0N7XPNMiwO9Ciqf2krAHKCyi+vuebBJ58k47hxQWEeweENVThcg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.2.tgz",
+			"integrity": "sha512-CRwh5myCbwuby/r/eAf+tjeVdiLPRsNpM4WXi9hWMLqN83PrMdn/2eHHprOHvrIz2OAcxhrJ7UGijZyEA4O1ew==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3034,17 +2993,17 @@
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.1.tgz",
-			"integrity": "sha512-hs79CmcmkWWg+INCZ2mGc/BeeyhXth/q2Yt0N7XPNMiwO9Ciqf2krAHKCyi+vuebBJ58k47hxQWEeweENVThcg==",
+			"version": "npm:@fluidframework/counter@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.2.tgz",
+			"integrity": "sha512-CRwh5myCbwuby/r/eAf+tjeVdiLPRsNpM4WXi9hWMLqN83PrMdn/2eHHprOHvrIz2OAcxhrJ7UGijZyEA4O1ew==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3076,24 +3035,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.1.tgz",
-			"integrity": "sha512-Q+d3pB2TfmgQ+Xji2TE83GaC//1w4Ow08ES4rO0Ehh/qZ59rd0Ouu9JdgeIEfItB2o7Efo/TpnZ4jeLf1B7xJg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.2.tgz",
+			"integrity": "sha512-0v0BtnW4SGU2kDVWC1HRoFAS0h1c93ANgz+1PVkVkVGJNnFWUM/G1nSk44mUfpfbwwolG2a9HK+Eznt/MdZPQQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3125,16 +3084,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.1.tgz",
-			"integrity": "sha512-ezcknk2m6R1w23ufxX8h7OFZ4RtcRI6y4hLWXToHGIWp57Ct3Tz4zj+3rqCfP95ZRSLQyHfsKU8g+sl39eUxLA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.2.tgz",
+			"integrity": "sha512-4JCUGn9OrNid3UpOOUpNRCEqr5s6xvJA6QAoAShXnry9+vmKC2llo1XrRIkNTyW3q6NBOhE39/rLqvceUgny6w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3149,16 +3108,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.1.tgz",
-			"integrity": "sha512-ezcknk2m6R1w23ufxX8h7OFZ4RtcRI6y4hLWXToHGIWp57Ct3Tz4zj+3rqCfP95ZRSLQyHfsKU8g+sl39eUxLA==",
+			"version": "npm:@fluidframework/datastore-definitions@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.2.tgz",
+			"integrity": "sha512-4JCUGn9OrNid3UpOOUpNRCEqr5s6xvJA6QAoAShXnry9+vmKC2llo1XrRIkNTyW3q6NBOhE39/rLqvceUgny6w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3173,24 +3132,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.1.tgz",
-			"integrity": "sha512-Q+d3pB2TfmgQ+Xji2TE83GaC//1w4Ow08ES4rO0Ehh/qZ59rd0Ouu9JdgeIEfItB2o7Efo/TpnZ4jeLf1B7xJg==",
+			"version": "npm:@fluidframework/datastore@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.2.tgz",
+			"integrity": "sha512-0v0BtnW4SGU2kDVWC1HRoFAS0h1c93ANgz+1PVkVkVGJNnFWUM/G1nSk44mUfpfbwwolG2a9HK+Eznt/MdZPQQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3222,15 +3181,15 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.1.tgz",
-			"integrity": "sha512-HarZynQR0l99gIqjnWTDnXY5+m7mNQax0dtS2TwFnqsLulxYx3hoBzJaUU9g9YuUmlEBxLtA/taRH3MyaguIgA==",
+			"version": "npm:@fluidframework/dds-interceptions@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.2.tgz",
+			"integrity": "sha512-KtRfhmVj9w3gH0C3fA2YJlNdLVBR9F/twB2wqMml6gP41yZvrcz6OvXr43m83My7aYZW7Q1ZR5UDwSuSsTd+yg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/sequence": "^1.2.1"
+				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/sequence": "^1.2.2"
 			}
 		},
 		"@fluidframework/debugger-previous": {
@@ -3257,16 +3216,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.1.tgz",
-			"integrity": "sha512-9RhRicdjFH3vS0poHCjLuaSwNKBp392PEkES2pD0UrO8GI8UVjIm0fO1GPz6ukst0MR6PAjOrlvyyxi6DSDZng==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.2.tgz",
+			"integrity": "sha512-DYSGM4IdwCc/VuEnTUNjRLWyHKI3mjUTMqKw7BhQroOh2olyM4r0lL+acSPjnH6VQjYJpDjcFO3A9SFZ5N5zwQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3303,12 +3262,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.1.tgz",
-			"integrity": "sha512-DCCwfb69dM4T+RcKaWgYd1tc9wvP0yoGm8gyn9IXEZ5HWHxOfXIicXmdMM48LUbFYEMgdyJscFnB/lmOqWckLg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.2.tgz",
+			"integrity": "sha512-3tEZY0Tri3cWH67m8+dtZDPdVT3MNxYJ1y6GywrY4xJFJVd1isJrIyWb8lljbSQPjNDR9tnG17p3uq1MxjRosw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3343,18 +3302,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.1.tgz",
-			"integrity": "sha512-01ATt8afRUClZV+PwvBsVQ2bMrUoMb/mIQZXb1GvPd+G9JLbCZSjAWvUgEYoJQSVc8lYcdoqY00/6GhBwe6sBA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.2.tgz",
+			"integrity": "sha512-7akTLrrvRSZmJKTBcJREqgmglWI9KV4d6lf3JrCzqPPkQBr6TkApmSf3J+8/xEsp5516MLdT0zDTMAxrNp7UOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3386,18 +3345,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.1.tgz",
-			"integrity": "sha512-01ATt8afRUClZV+PwvBsVQ2bMrUoMb/mIQZXb1GvPd+G9JLbCZSjAWvUgEYoJQSVc8lYcdoqY00/6GhBwe6sBA==",
+			"version": "npm:@fluidframework/driver-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.2.tgz",
+			"integrity": "sha512-7akTLrrvRSZmJKTBcJREqgmglWI9KV4d6lf3JrCzqPPkQBr6TkApmSf3J+8/xEsp5516MLdT0zDTMAxrNp7UOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3429,13 +3388,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.1.tgz",
-			"integrity": "sha512-addWBUeiUOFALjF3poQ+jlrbY1r9jgZPnTowjlCl1ZjDXFBRFYxFJ9rAvXfHvO9jWLR/tBTFqcwwZ3OchsWcNg==",
+			"version": "npm:@fluidframework/driver-web-cache@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.2.tgz",
+			"integrity": "sha512-WqXHVqJvHtaf0sMjoKjA4efx85LW3lxaGwmUDcZZ02dbsLOZee/l/CgR8pLJ5wY03CoQBNFYUCS++b3hYegIBQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3482,22 +3441,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.1.tgz",
-			"integrity": "sha512-QCQURqqv/PR9oxQLzllgD016eIO4PzN7sl9rwfm19UYT8lIr8bmH0HmSIULztm93aAKoqi2bD46GLxnIYXF/Kw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.2.tgz",
+			"integrity": "sha512-qJ1juVJ/oHqsHmCba/nqUv0JalXj/a3heQVJRBsLPSBkEf+Ss7FqfJeBCwkxvpkVczWXQnKu0UVbBDbAk0E0nA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1"
+				"@fluidframework/request-handler": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3511,22 +3470,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.1.tgz",
-			"integrity": "sha512-QCQURqqv/PR9oxQLzllgD016eIO4PzN7sl9rwfm19UYT8lIr8bmH0HmSIULztm93aAKoqi2bD46GLxnIYXF/Kw==",
+			"version": "npm:@fluidframework/fluid-static@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.2.tgz",
+			"integrity": "sha512-qJ1juVJ/oHqsHmCba/nqUv0JalXj/a3heQVJRBsLPSBkEf+Ss7FqfJeBCwkxvpkVczWXQnKu0UVbBDbAk0E0nA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1"
+				"@fluidframework/request-handler": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3540,23 +3499,23 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.1.tgz",
-			"integrity": "sha512-xK0sg2sI/aVyhJJQ0Xq6JoH/ImWGfEoHMfwYmU5Kv4aHJyPyNG7slKvoHtrXF/F7VKBUUzAo2XIKCvEup5Odgg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.2.tgz",
+			"integrity": "sha512-Drgs1Ql5n/SDu0VEhYodTsmG3I0S/+hfAjUNJDMR658gHlDURHfS29/IL0WEUH3LqhNBQQKlnDrX2/LjVBXC4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.1.tgz",
-			"integrity": "sha512-xK0sg2sI/aVyhJJQ0Xq6JoH/ImWGfEoHMfwYmU5Kv4aHJyPyNG7slKvoHtrXF/F7VKBUUzAo2XIKCvEup5Odgg==",
+			"version": "npm:@fluidframework/garbage-collector@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.2.tgz",
+			"integrity": "sha512-Drgs1Ql5n/SDu0VEhYodTsmG3I0S/+hfAjUNJDMR658gHlDURHfS29/IL0WEUH3LqhNBQQKlnDrX2/LjVBXC4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3590,17 +3549,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.1.tgz",
-			"integrity": "sha512-5xjp61tctTRU0Qeb3UbyYqwaiQt1vFKrSf+IjkhOAwGEu7/6bCcrYGjxepEsVnk5dK6CtlMowMujVDYevFxLkw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.2.tgz",
+			"integrity": "sha512-2uZsBY789adZFVLPcDKQBXZ3SuKEgwjXF+5XaDoyBldjk39e6K+NIA7YUbv1RES5i3eSQn5iBpEOlL1+67kDYg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -3615,17 +3574,17 @@
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.1.tgz",
-			"integrity": "sha512-5xjp61tctTRU0Qeb3UbyYqwaiQt1vFKrSf+IjkhOAwGEu7/6bCcrYGjxepEsVnk5dK6CtlMowMujVDYevFxLkw==",
+			"version": "npm:@fluidframework/ink@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.2.tgz",
+			"integrity": "sha512-2uZsBY789adZFVLPcDKQBXZ3SuKEgwjXF+5XaDoyBldjk39e6K+NIA7YUbv1RES5i3eSQn5iBpEOlL1+67kDYg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -3640,18 +3599,18 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.1.tgz",
-			"integrity": "sha512-EEepZk68gZkNK7/Ge+NcygEvQkM1IYgzAo/TfeBqPJHMgFYttmvP6nh6KcX2+yv7azHHyjySEbfAqdyInbaRqw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.2.tgz",
+			"integrity": "sha512-9vgh2vhdoRtO7eFpwumLgIEi751VbxPMtKzJPUUkSK+7rWAoAMpCy8Ws1JwZSXNxm/SEI8WfhRcECT9Sop+N7Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -3827,18 +3786,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.1.tgz",
-			"integrity": "sha512-EEepZk68gZkNK7/Ge+NcygEvQkM1IYgzAo/TfeBqPJHMgFYttmvP6nh6KcX2+yv7azHHyjySEbfAqdyInbaRqw==",
+			"version": "npm:@fluidframework/local-driver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.2.tgz",
+			"integrity": "sha512-9vgh2vhdoRtO7eFpwumLgIEi751VbxPMtKzJPUUkSK+7rWAoAMpCy8Ws1JwZSXNxm/SEI8WfhRcECT9Sop+N7Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4014,20 +3973,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.1.tgz",
-			"integrity": "sha512-uW2b+3j5+Zf1BkB1wAk3amLoj10SJ3cbpDKIU2MTdNK59WW6h4YGzltY4Rnr108ZIkrlfkkBWd1kODE9vjBbzg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.2.tgz",
+			"integrity": "sha512-84F1XSHr1q9Hm1iVELv59Stm2k6Zs+eCDOyJX7hNecVPqN3m5ZjKa52YPxHOPo82dlckdiNYZ1pFHGyZP0Ovyg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4042,20 +4001,20 @@
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.1.tgz",
-			"integrity": "sha512-uW2b+3j5+Zf1BkB1wAk3amLoj10SJ3cbpDKIU2MTdNK59WW6h4YGzltY4Rnr108ZIkrlfkkBWd1kODE9vjBbzg==",
+			"version": "npm:@fluidframework/map@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.2.tgz",
+			"integrity": "sha512-84F1XSHr1q9Hm1iVELv59Stm2k6Zs+eCDOyJX7hNecVPqN3m5ZjKa52YPxHOPo82dlckdiNYZ1pFHGyZP0Ovyg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4070,21 +4029,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.1.tgz",
-			"integrity": "sha512-NFU1r6lP8MPudEexHdZ/sbaSOGbtBYt4G8oUytvDzarXzOig9fiRJUCtXinKZx5ubum8DyxPvzITxrHCImK+Mw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.2.tgz",
+			"integrity": "sha512-a0hcBzcKT1qfxtHk2eLc4RAY08cDr2TX5cFHx8AOi0DmOef0Cx7hbe67/CCLPXtssEe52eYokwos38rjkb1IWQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4116,21 +4075,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.1.tgz",
-			"integrity": "sha512-NFU1r6lP8MPudEexHdZ/sbaSOGbtBYt4G8oUytvDzarXzOig9fiRJUCtXinKZx5ubum8DyxPvzITxrHCImK+Mw==",
+			"version": "npm:@fluidframework/matrix@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.2.tgz",
+			"integrity": "sha512-a0hcBzcKT1qfxtHk2eLc4RAY08cDr2TX5cFHx8AOi0DmOef0Cx7hbe67/CCLPXtssEe52eYokwos38rjkb1IWQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4162,21 +4121,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.1.tgz",
-			"integrity": "sha512-8yt1rPI2upS4vmwsaLOZnKbd3XpVYknw7JmOoHppyonREO9Tz+JbLXdUXHq4ycnhbGJxwoMCIwCwGyaWLW8y8g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.2.tgz",
+			"integrity": "sha512-vwD61h9kvquj6vD4qLFfyCZEtIlYYkmimUdm4c/tBQ9JRZk/7e5jZ8JxaVrJLY1Tn5FZDZsiv3CM8MhKl7rMJA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4190,21 +4149,21 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.1.tgz",
-			"integrity": "sha512-8yt1rPI2upS4vmwsaLOZnKbd3XpVYknw7JmOoHppyonREO9Tz+JbLXdUXHq4ycnhbGJxwoMCIwCwGyaWLW8y8g==",
+			"version": "npm:@fluidframework/merge-tree@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.2.tgz",
+			"integrity": "sha512-vwD61h9kvquj6vD4qLFfyCZEtIlYYkmimUdm4c/tBQ9JRZk/7e5jZ8JxaVrJLY1Tn5FZDZsiv3CM8MhKl7rMJA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4218,12 +4177,12 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.1.tgz",
-			"integrity": "sha512-QYA0lW1G+I1Nn23o+7WwVzHpAXdRUv7bqdrCPXh8Ge76B6jxNg7JizDgkbuvF5NbpWIH2WCAV1KtdAJ9nltaNg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.2.tgz",
+			"integrity": "sha512-czSIZ5i68u1ccMgpKlxKq/i3vDBWQdFaY3SW2QrraxrivIuH2Qn2z1ehzQPQfk3nZGiwtG/M1q9AY5g0iT7+1w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
 				"mocha": "^10.0.0"
 			}
 		},
@@ -4238,50 +4197,50 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.1.tgz",
-			"integrity": "sha512-G+k6sW4ClrBfdplCG6muDBksjzMALjN0o0/etnJ1z09g7zLr5lV5m91hFAttVjN8WhrjbOqhu2KTBVHFmymzXA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.2.tgz",
+			"integrity": "sha512-xUzn8NyWTzutDu1o8Qvcg8fWSj2hvoNUx5HfeWki7paOlB6HhRKmcRp3+uMIHEqpQQjPGLTYJx9VQQ1tv4omMA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.1.tgz",
-			"integrity": "sha512-G+k6sW4ClrBfdplCG6muDBksjzMALjN0o0/etnJ1z09g7zLr5lV5m91hFAttVjN8WhrjbOqhu2KTBVHFmymzXA==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.2.tgz",
+			"integrity": "sha512-xUzn8NyWTzutDu1o8Qvcg8fWSj2hvoNUx5HfeWki7paOlB6HhRKmcRp3+uMIHEqpQQjPGLTYJx9VQQ1tv4omMA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.1.tgz",
-			"integrity": "sha512-+lgMhWP6yHQ5vQ0YnCKI0oxXPV9FEasMuf+rl4g6y9nYT2qnGDKAfUGOvBw5CSQnf3ep5CfiRQSHNBEDzAFc6A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.2.tgz",
+			"integrity": "sha512-yUBGPB2SHJy1Zyk+MnsDzXLhoFj3GG4Ogt5dqBI3FSStORQdRBjjtAzT6u+GQnqVmjeoprh3VYd0/B3Qqq/Zmg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4315,38 +4274,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.1.tgz",
-			"integrity": "sha512-9sd/Z0Gmvy9EILYrPEZKZk2B9tpLrDtjO7O1CmF59aVVR2+Jd+ieIC2rgaTXFLy7t3mwZvuuhiUJ42P8P6JF7g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.2.tgz",
+			"integrity": "sha512-BMo66EiBCJgjCaWalRlvyxROWELfn1dN4eVmpS7ZhOGnPvdffMfOhlsQUSEKdjUY8R6PRBvFwD9cMju1ZPqc0g==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.1"
+				"@fluidframework/driver-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.1.tgz",
-			"integrity": "sha512-9sd/Z0Gmvy9EILYrPEZKZk2B9tpLrDtjO7O1CmF59aVVR2+Jd+ieIC2rgaTXFLy7t3mwZvuuhiUJ42P8P6JF7g==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.2.tgz",
+			"integrity": "sha512-BMo66EiBCJgjCaWalRlvyxROWELfn1dN4eVmpS7ZhOGnPvdffMfOhlsQUSEKdjUY8R6PRBvFwD9cMju1ZPqc0g==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.1"
+				"@fluidframework/driver-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.1.tgz",
-			"integrity": "sha512-+lgMhWP6yHQ5vQ0YnCKI0oxXPV9FEasMuf+rl4g6y9nYT2qnGDKAfUGOvBw5CSQnf3ep5CfiRQSHNBEDzAFc6A==",
+			"version": "npm:@fluidframework/odsp-driver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.2.tgz",
+			"integrity": "sha512-yUBGPB2SHJy1Zyk+MnsDzXLhoFj3GG4Ogt5dqBI3FSStORQdRBjjtAzT6u+GQnqVmjeoprh3VYd0/B3Qqq/Zmg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4380,39 +4339,39 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.1.tgz",
-			"integrity": "sha512-Y/pa5n07HB4u1bMEKYNC4qS9RwXjA9SyCuzTRV+0DLsQ/aTbdKRF3ylI+UOoAKGRbSHh475V12PfXS0JsEmu+A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.2.tgz",
+			"integrity": "sha512-oR/LTKcQiRfG6XWpp5+sGmuZt/8R6cR0wt9I4xWGMrgM2kTHzpH0H7p0LiNrH4FrcWXcSaeCSSPWVp9tkSEM5A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/odsp-driver": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1"
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-driver": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.1.tgz",
-			"integrity": "sha512-Y/pa5n07HB4u1bMEKYNC4qS9RwXjA9SyCuzTRV+0DLsQ/aTbdKRF3ylI+UOoAKGRbSHh475V12PfXS0JsEmu+A==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.2.tgz",
+			"integrity": "sha512-oR/LTKcQiRfG6XWpp5+sGmuZt/8R6cR0wt9I4xWGMrgM2kTHzpH0H7p0LiNrH4FrcWXcSaeCSSPWVp9tkSEM5A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/odsp-driver": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1"
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-driver": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.1.tgz",
-			"integrity": "sha512-TG5HDTIi/kxPHhifg60Dsr6yCh/Qlgr4AG/wHXTLCh1fuBhuKIAt3cUajjrTKefYe4ot9s+0bAQdw6qF9QVEWA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.2.tgz",
+			"integrity": "sha512-XYPcw03IJQm72ub7Or4gOCt9aGJR6Wb/RUt4CQLF8W5lFAXaeOYzKB/u4dMbFmMf3T66kZ6rvF+8aA7GOdTT7w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4427,17 +4386,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.1.tgz",
-			"integrity": "sha512-TG5HDTIi/kxPHhifg60Dsr6yCh/Qlgr4AG/wHXTLCh1fuBhuKIAt3cUajjrTKefYe4ot9s+0bAQdw6qF9QVEWA==",
+			"version": "npm:@fluidframework/ordered-collection@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.2.tgz",
+			"integrity": "sha512-XYPcw03IJQm72ub7Or4gOCt9aGJR6Wb/RUt4CQLF8W5lFAXaeOYzKB/u4dMbFmMf3T66kZ6rvF+8aA7GOdTT7w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4481,17 +4440,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.1.tgz",
-			"integrity": "sha512-ja/ZK1+rckGiibTwd+tApTd1KMhkV3DoeMFbZFArmrIxkCzPNHnP4m4RmTC+xgE0QYPBC/HOKeNd+gMlIwGDcw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.2.tgz",
+			"integrity": "sha512-RiiD15O4mixkerHptociuOa+wqOA+hp6pkM3eMhkHqKO0g1JYOrUfK6g4hiPnibwP8fZAK1r8oZpDugzyTgZ3Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4521,17 +4480,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.1.tgz",
-			"integrity": "sha512-ja/ZK1+rckGiibTwd+tApTd1KMhkV3DoeMFbZFArmrIxkCzPNHnP4m4RmTC+xgE0QYPBC/HOKeNd+gMlIwGDcw==",
+			"version": "npm:@fluidframework/register-collection@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.2.tgz",
+			"integrity": "sha512-RiiD15O4mixkerHptociuOa+wqOA+hp6pkM3eMhkHqKO0g1JYOrUfK6g4hiPnibwP8fZAK1r8oZpDugzyTgZ3Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4561,16 +4520,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.1.tgz",
-			"integrity": "sha512-3lv0gEs7c2EjdGkzSdoCvI/wQZoSbh6UwIlr12kI7eUaUyFbiRS+9jidTNhRR2az8HyYeXNcmyw6sIKML/i8eQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.2.tgz",
+			"integrity": "sha512-VRm7JjHGpL58g6ZnJbP6lKUNrV82pL85kNpAM495A55fwLYCC0Q5lynIFpzgqxhy4S/pJi7hQT/kUO4URyEwVw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4584,16 +4543,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.1.tgz",
-			"integrity": "sha512-3lv0gEs7c2EjdGkzSdoCvI/wQZoSbh6UwIlr12kI7eUaUyFbiRS+9jidTNhRR2az8HyYeXNcmyw6sIKML/i8eQ==",
+			"version": "npm:@fluidframework/replay-driver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.2.tgz",
+			"integrity": "sha512-VRm7JjHGpL58g6ZnJbP6lKUNrV82pL85kNpAM495A55fwLYCC0Q5lynIFpzgqxhy4S/pJi7hQT/kUO4URyEwVw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4607,44 +4566,44 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.1.tgz",
-			"integrity": "sha512-BdRtF6Qid/1MXDV6fILvHoS0ggBvMhrFqbTCJCQrpNCBVLaTOhpmG34DtSzbAGR8+FlqxbDrydSEhhSkN2UGxA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.2.tgz",
+			"integrity": "sha512-rDgY7E0A3bgOOOSVDCPgRQx+WhWQXGel9jtVflvjox5gwFZcew2HJvaIhNbpIADSoM8g35J41VyM9tvXd8kPXQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1"
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.1.tgz",
-			"integrity": "sha512-BdRtF6Qid/1MXDV6fILvHoS0ggBvMhrFqbTCJCQrpNCBVLaTOhpmG34DtSzbAGR8+FlqxbDrydSEhhSkN2UGxA==",
+			"version": "npm:@fluidframework/request-handler@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.2.tgz",
+			"integrity": "sha512-rDgY7E0A3bgOOOSVDCPgRQx+WhWQXGel9jtVflvjox5gwFZcew2HJvaIhNbpIADSoM8g35J41VyM9tvXd8kPXQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1"
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.1.tgz",
-			"integrity": "sha512-4QyhRzvhSCicU+W2BjU625yoWg+zQcOE0WGZsHWnDEPTBWAuHOTTqNQ+PBrFfGjL8Yabg4n3SIu5l57yMFEsAA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.2.tgz",
+			"integrity": "sha512-TRJNVG/L0JAthm4i/kpCdziLreRe6wFQZjzsuQrp4J5knfdo2/Dg/tB5AzvJONv5m3iMgA1SPrOFrj324lSseQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4705,20 +4664,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.1.tgz",
-			"integrity": "sha512-4QyhRzvhSCicU+W2BjU625yoWg+zQcOE0WGZsHWnDEPTBWAuHOTTqNQ+PBrFfGjL8Yabg4n3SIu5l57yMFEsAA==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.2.tgz",
+			"integrity": "sha512-TRJNVG/L0JAthm4i/kpCdziLreRe6wFQZjzsuQrp4J5knfdo2/Dg/tB5AzvJONv5m3iMgA1SPrOFrj324lSseQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4779,13 +4738,13 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.1.tgz",
-			"integrity": "sha512-z9I34kvrihv2CvgU2xr91zQJdvBYQSux7cN4Gmk8WCMEU5ufCVXaJ2gJhWuEigD5+AzmIjPU82lsurnQfyfxCg==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.2.tgz",
+			"integrity": "sha512-b2TOwMPve46llFVXUFrsbmfPJb4Sik7d1Id4LqnMe68c1veWTWWlq7LXycO7VgG5e6KUn39t6CBtsiixa+8iFw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			},
@@ -4801,15 +4760,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.1.tgz",
-			"integrity": "sha512-RT8cWIXR0PrcV05UabqxPIRX9agxoGsf0K6/4SZYkM7KMwKZqLPfgLs038q83uo9aZBmfr5/e5eRv95VbJoHfw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.2.tgz",
+			"integrity": "sha512-dlbwCKNSp7kEjpvEuZSnVUshbcFuu0BMZZOGqGqWwvh1ataw59IIYRX02auKe5O4r4xZ/PYVE9UnGreNshqj8A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -4825,15 +4784,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.1.tgz",
-			"integrity": "sha512-RT8cWIXR0PrcV05UabqxPIRX9agxoGsf0K6/4SZYkM7KMwKZqLPfgLs038q83uo9aZBmfr5/e5eRv95VbJoHfw==",
+			"version": "npm:@fluidframework/runtime-definitions@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.2.tgz",
+			"integrity": "sha512-dlbwCKNSp7kEjpvEuZSnVUshbcFuu0BMZZOGqGqWwvh1ataw59IIYRX02auKe5O4r4xZ/PYVE9UnGreNshqj8A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -4849,21 +4808,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.1.tgz",
-			"integrity": "sha512-X5PURvg5m3KWwHG9CKts+fE7JcjvffiC0IopA51aM+AGM7E04M4biRyrCAQazR1OwheM3M3z/pMHRfBI2eaFaQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.2.tgz",
+			"integrity": "sha512-DT36SnJEShWR9lgEmTUzvkMMm0oLll2hmNelRxiortSl67Qjky8ujxlsYCnQCZpwPXJSJZkzACbDO9w2+ejdKQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4893,21 +4852,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.1.tgz",
-			"integrity": "sha512-X5PURvg5m3KWwHG9CKts+fE7JcjvffiC0IopA51aM+AGM7E04M4biRyrCAQazR1OwheM3M3z/pMHRfBI2eaFaQ==",
+			"version": "npm:@fluidframework/runtime-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.2.tgz",
+			"integrity": "sha512-DT36SnJEShWR9lgEmTUzvkMMm0oLll2hmNelRxiortSl67Qjky8ujxlsYCnQCZpwPXJSJZkzACbDO9w2+ejdKQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/garbage-collector": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/garbage-collector": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4937,21 +4896,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.1.tgz",
-			"integrity": "sha512-2np0sho6uZpbz/d+ndvyGBz3A5iP4CYZTvrngw+2nuvJE22XKd8UkwIOxn08lsPcPaKPS38JOyAOk27P4RiTcQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.2.tgz",
+			"integrity": "sha512-j4I+9qgDMtFgMH1uP9Qv2LTFkAK1rxAd7e11kDJ5E/B2NQwFOfUOTtUDPYGe0q2HJMMqo6fSWYfZDAEB20LfEw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4966,21 +4925,21 @@
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.1.tgz",
-			"integrity": "sha512-2np0sho6uZpbz/d+ndvyGBz3A5iP4CYZTvrngw+2nuvJE22XKd8UkwIOxn08lsPcPaKPS38JOyAOk27P4RiTcQ==",
+			"version": "npm:@fluidframework/sequence@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.2.tgz",
+			"integrity": "sha512-j4I+9qgDMtFgMH1uP9Qv2LTFkAK1rxAd7e11kDJ5E/B2NQwFOfUOTtUDPYGe0q2HJMMqo6fSWYfZDAEB20LfEw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -5635,9 +5594,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.5.8",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-					"integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
+					"version": "7.5.9",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+					"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
 				},
 				"y18n": {
 					"version": "5.0.8",
@@ -6138,22 +6097,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.1.tgz",
-			"integrity": "sha512-Ybsf4x+KRDQdKzQNvsHIkchKwPMtnEbFNJfspuJYnRwN/Ujzq1CO4gCzyX7nvXm+DFMhlMi/JmfAKD+rnJrEHg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.2.tgz",
+			"integrity": "sha512-uRTmx2/88Pq2pl2/Wb9CBi9LxTW5TCez0oeZL1Zn0xxIIX0437t390+rm/7lsjasEubuSBV0VC39UKp1deI/TA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6168,22 +6127,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.1.tgz",
-			"integrity": "sha512-Ybsf4x+KRDQdKzQNvsHIkchKwPMtnEbFNJfspuJYnRwN/Ujzq1CO4gCzyX7nvXm+DFMhlMi/JmfAKD+rnJrEHg==",
+			"version": "npm:@fluidframework/shared-object-base@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.2.tgz",
+			"integrity": "sha512-uRTmx2/88Pq2pl2/Wb9CBi9LxTW5TCez0oeZL1Zn0xxIIX0437t390+rm/7lsjasEubuSBV0VC39UKp1deI/TA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/container-utils": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6198,17 +6157,17 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.1.tgz",
-			"integrity": "sha512-vfN4cspbBAdVhcV3B99An2amh4bOhNurZMTncXjg7JKArxMuF544iCCC+YWJqmeSymRqE/WndXFZOs4TzaLWfQ==",
+			"version": "npm:@fluidframework/shared-summary-block@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.2.tgz",
+			"integrity": "sha512-r8qPHUF1Upc0l1LWt45qkGkl5FVHx2mQVfnRLzWjhsybamwwTwM2o5z+Tk0lt5WTr+X+74D026cTP+y6e5sTeQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/shared-object-base": "^1.2.1"
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/shared-object-base": "^1.2.2"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -6222,19 +6181,19 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.1.tgz",
-			"integrity": "sha512-XLD2wyUcj7QMsjOSBgZpMNKAiuycXrF5dPwyRbMB35DgxuA1MggCPw1sl7D1b22YRf7v/WrHPI4Vz9CUqAVUbA=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.2.tgz",
+			"integrity": "sha512-4ajrHGcq3fxnczjFNM5tdF5i+gzz7Nco7UnOR5Q9b7122nxMBQhBBGC086VpdJvUCQLBDTM9nLNuUaTx+JveCQ=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.1.tgz",
-			"integrity": "sha512-XLD2wyUcj7QMsjOSBgZpMNKAiuycXrF5dPwyRbMB35DgxuA1MggCPw1sl7D1b22YRf7v/WrHPI4Vz9CUqAVUbA=="
+			"version": "npm:@fluidframework/synthesize@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.2.tgz",
+			"integrity": "sha512-4ajrHGcq3fxnczjFNM5tdF5i+gzz7Nco7UnOR5Q9b7122nxMBQhBBGC086VpdJvUCQLBDTM9nLNuUaTx+JveCQ=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.1.tgz",
-			"integrity": "sha512-kUlHkQsDC6xkT0dButPJjtclYXM7TmnT30+zQEiLbLMP5X39vjz0uDcFX+nhorevaiHRoHbcN3RdlAza7m1DqA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.2.tgz",
+			"integrity": "sha512-7EWIhEL7BTCkpumPG0F8bjPOyN5hyu0MV9SRO7K668FSBvTv+isAuUY2mPhtdddx+nexXXWqXYyGYRUcIdlf4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6244,9 +6203,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.1.tgz",
-			"integrity": "sha512-kUlHkQsDC6xkT0dButPJjtclYXM7TmnT30+zQEiLbLMP5X39vjz0uDcFX+nhorevaiHRoHbcN3RdlAza7m1DqA==",
+			"version": "npm:@fluidframework/telemetry-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.2.tgz",
+			"integrity": "sha512-7EWIhEL7BTCkpumPG0F8bjPOyN5hyu0MV9SRO7K668FSBvTv+isAuUY2mPhtdddx+nexXXWqXYyGYRUcIdlf4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6256,12 +6215,12 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.1.tgz",
-			"integrity": "sha512-j5L3xr2GVn8sWDA9Rss8THOxLEtx7P21SlY3EdBO4BZLupbDSpZHGopYPMg68qhVQPuBZ1nHNcWHWUIYIxViBA==",
+			"version": "npm:@fluidframework/test-client-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.2.tgz",
+			"integrity": "sha512-R/LmVrL67pcyaZoNoHU/JLDINxlODz6787kQQgQjBV4pBYfrx1wszEtzVSUFhkoNkF970iSlhdQOrk/vWtFe+A==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
 				"sillyname": "^0.1.0"
 			},
 			"dependencies": {
@@ -6276,13 +6235,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.1.tgz",
-			"integrity": "sha512-uffs1vMcqJMijddaV6vPnEj7jKf6cPEF+4gYn8QOP98UESAbZs4XL1YI3M71uCGDZBQ12KR/MIrspFnqZH7QXg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.2.tgz",
+			"integrity": "sha512-e/LPVQWab4Td97g0wEzmqV3WUYU7LnontXQ5vK4RcH8gWIjQ+Oh+2sfL9lxPVKzUGwUVwa18R745mYEi9uhi9w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -6320,27 +6279,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.1.tgz",
-			"integrity": "sha512-l2F0ucCEOqXBSpHvSzuU7RnA2m6OmCKNu0vxFKlflu6hr2BWTF8I/HdNy23gWJasQI7w2JQREP8V70/B4Xy7Iw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.2.tgz",
+			"integrity": "sha512-8h6cF+uyEdt2CNrQjrc4EferQFDkTaAER4h79gHFjRtkRPeQhGU1PaP7RmycCgrfPSo0z/8Qk7rejnhYmhbgMA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/local-driver": "^1.2.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
-				"@fluidframework/odsp-driver": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
-				"@fluidframework/odsp-urlresolver": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/local-driver": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-driver": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-urlresolver": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
-				"@fluidframework/test-pairwise-generator": "^1.2.1",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
-				"@fluidframework/tinylicious-driver": "^1.2.1",
-				"@fluidframework/tool-utils": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-pairwise-generator": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/tinylicious-driver": "^1.2.2",
+				"@fluidframework/tool-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6513,27 +6472,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.1.tgz",
-			"integrity": "sha512-l2F0ucCEOqXBSpHvSzuU7RnA2m6OmCKNu0vxFKlflu6hr2BWTF8I/HdNy23gWJasQI7w2JQREP8V70/B4Xy7Iw==",
+			"version": "npm:@fluidframework/test-drivers@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.2.tgz",
+			"integrity": "sha512-8h6cF+uyEdt2CNrQjrc4EferQFDkTaAER4h79gHFjRtkRPeQhGU1PaP7RmycCgrfPSo0z/8Qk7rejnhYmhbgMA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/local-driver": "^1.2.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
-				"@fluidframework/odsp-driver": "^1.2.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.1",
-				"@fluidframework/odsp-urlresolver": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/local-driver": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-driver": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-urlresolver": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
-				"@fluidframework/test-pairwise-generator": "^1.2.1",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
-				"@fluidframework/tinylicious-driver": "^1.2.1",
-				"@fluidframework/tool-utils": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-pairwise-generator": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/tinylicious-driver": "^1.2.2",
+				"@fluidframework/tool-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6706,14 +6665,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.1.tgz",
-			"integrity": "sha512-SqVm2z4Uh0Ni9CCGs6rmHIQbXomImnN4/PVo9etCQ1I4jmx4PNODzhYDYRZr+HauUSy1twrQsty31inSzvPD+Q==",
+			"version": "npm:@fluidframework/test-loader-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.2.tgz",
+			"integrity": "sha512-EgeYldMi5PXVLVy1UGY0h2abJygCTPIala1XSjbTr3yHBBh+auKf37LQaRB4FliIikcWrKcfK8yvIgbck44GPw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -6728,40 +6687,40 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.1.tgz",
-			"integrity": "sha512-B2q5gPJsEaVY8Ue0Csu3yQimBlpRAnghpv9jS48P5RRSocQqOEOgps2bsNkJcHcU+btCxGRiME35pLC8kXgWFg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.2.tgz",
+			"integrity": "sha512-lg39KINpZfx2VAmKh8rL2Mcz5X+OFq5torMT2RaMlMs9ccS+wsrg0jPNC6FxtKwwHI/CbAqpHmcb85amiZNbpw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.1.tgz",
-			"integrity": "sha512-B2q5gPJsEaVY8Ue0Csu3yQimBlpRAnghpv9jS48P5RRSocQqOEOgps2bsNkJcHcU+btCxGRiME35pLC8kXgWFg==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.2.tgz",
+			"integrity": "sha512-lg39KINpZfx2VAmKh8rL2Mcz5X+OFq5torMT2RaMlMs9ccS+wsrg0jPNC6FxtKwwHI/CbAqpHmcb85amiZNbpw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.1.tgz",
-			"integrity": "sha512-uqnXdRwZ1PiNtf8bvEv5fXALYiaM9G/sHkAgi00fbawZVHjPw7PlRjiSKMYOVItv4p6xWoM0eO3RZXEUJC808A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.2.tgz",
+			"integrity": "sha512-+jyqdp9qtlu/jgu+6N2FqNZfvwA0rQDozI3sv4b8O9xPvl7X1CZ+idhYxpJR176TGfdUIGw5+vh8mduilSeU0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6778,22 +6737,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.1.tgz",
-			"integrity": "sha512-uqnXdRwZ1PiNtf8bvEv5fXALYiaM9G/sHkAgi00fbawZVHjPw7PlRjiSKMYOVItv4p6xWoM0eO3RZXEUJC808A==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.2.tgz",
+			"integrity": "sha512-+jyqdp9qtlu/jgu+6N2FqNZfvwA0rQDozI3sv4b8O9xPvl7X1CZ+idhYxpJR176TGfdUIGw5+vh8mduilSeU0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6816,32 +6775,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.1.tgz",
-			"integrity": "sha512-4zjHa17f1i4SUDFnnDOVGkX2kYVAVyrqSJT6Scm3Jj0GW9lMAWKkERySdzykwyB/zmYmhHqzdnYngsTUrQH9VA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.2.tgz",
+			"integrity": "sha512-DtzmQ4I194Ha93BIvc8yoU3DIACjD205fBtoMRST7blnu8sSGUjIgKkGlwJlsK63MDxPggGvNPV96KCPSm6NsA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/local-driver": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/local-driver": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.1",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/request-handler": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -6857,32 +6816,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.1.tgz",
-			"integrity": "sha512-4zjHa17f1i4SUDFnnDOVGkX2kYVAVyrqSJT6Scm3Jj0GW9lMAWKkERySdzykwyB/zmYmhHqzdnYngsTUrQH9VA==",
+			"version": "npm:@fluidframework/test-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.2.tgz",
+			"integrity": "sha512-DtzmQ4I194Ha93BIvc8yoU3DIACjD205fBtoMRST7blnu8sSGUjIgKkGlwJlsK63MDxPggGvNPV96KCPSm6NsA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/datastore": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/local-driver": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/container-runtime-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/datastore": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/local-driver": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.1",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/telemetry-utils": "^1.2.1",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
-				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/request-handler": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.2",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -6898,34 +6857,34 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.1.tgz",
-			"integrity": "sha512-QKjRsdg/R264TxrWyOhZ1U7t0a5JB/X1c48/hplc971BLpxm6xOL1rd1Q/HanYNbwaKv/JY47q3yl/JcwdIw7g==",
+			"version": "npm:@fluidframework/test-version-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.2.tgz",
+			"integrity": "sha512-RdQ7u1MsdffEdA3TGbTJ3NCAA6g2JJCoj2asWbiGLGCh6aqUrndXrX+cB0rtDk/EED1nlWlOIdyPSO58n/HF5A==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.1",
-				"@fluidframework/cell": "^1.2.1",
+				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/cell": "^1.2.2",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/container-runtime": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/counter": "^1.2.1",
-				"@fluidframework/datastore-definitions": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/ink": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
-				"@fluidframework/matrix": "^1.2.1",
-				"@fluidframework/mocha-test-setup": "^1.2.1",
-				"@fluidframework/ordered-collection": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/container-runtime": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/counter": "^1.2.2",
+				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/ink": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/matrix": "^1.2.2",
+				"@fluidframework/mocha-test-setup": "^1.2.2",
+				"@fluidframework/ordered-collection": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.2.1",
-				"@fluidframework/runtime-definitions": "^1.2.1",
-				"@fluidframework/sequence": "^1.2.1",
-				"@fluidframework/test-driver-definitions": "^1.2.1",
-				"@fluidframework/test-drivers": "^1.2.1",
-				"@fluidframework/test-utils": "^1.2.1",
+				"@fluidframework/register-collection": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/sequence": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-drivers": "^1.2.2",
+				"@fluidframework/test-utils": "^1.2.2",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
@@ -6942,22 +6901,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.1.tgz",
-			"integrity": "sha512-RDPowAv8ZZlTpBxbKRK6odcnfOO5Z3nsbjNpPAXN61Y+n98rRgldTSq0J+SRuqviVeqQkbw7KwJZ4iHPwFnmQA==",
+			"version": "npm:@fluidframework/tinylicious-client@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.2.tgz",
+			"integrity": "sha512-SOLFn0rI9lRHbiIaZq9Q2PO57oQviZxE/aKzObLG6fjBNIbbW/ebrbKmNx+nXadB0Ao7OcJ2f9Ps5e9MhdJt/Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
-				"@fluidframework/fluid-static": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/fluid-static": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
-				"@fluidframework/runtime-utils": "^1.2.1",
-				"@fluidframework/tinylicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/tinylicious-driver": "^1.2.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6972,15 +6931,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.1.tgz",
-			"integrity": "sha512-8LXtxctyluRyhalY3geomoYjRfLPii8x6hGRM8e3hcVpwOc9ZZayVmovHeB2qwZJZTNEA57BPHZVibMv41FPhw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.2.tgz",
+			"integrity": "sha512-3YigUpJ/Vl5+aTPNJ6XaJX3YdW0wGE81uMhMDOjUGK8SIxBWW1TZSNXPKlm58M2rhKCKrvVklCQWaFlez65jgQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -7038,15 +6997,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.1.tgz",
-			"integrity": "sha512-8LXtxctyluRyhalY3geomoYjRfLPii8x6hGRM8e3hcVpwOc9ZZayVmovHeB2qwZJZTNEA57BPHZVibMv41FPhw==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.2.tgz",
+			"integrity": "sha512-3YigUpJ/Vl5+aTPNJ6XaJX3YdW0wGE81uMhMDOjUGK8SIxBWW1TZSNXPKlm58M2rhKCKrvVklCQWaFlez65jgQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/driver-definitions": "^1.2.1",
-				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/driver-utils": "^1.2.2",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.2",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -7104,12 +7063,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.1.tgz",
-			"integrity": "sha512-jyx9QtxJleK2vXi8HL0Fg0a83E/LLoyGT7sWKbnjRQ8b193ExAkzBIkHACCyADDsgLysVuH3esBAHdWsEqTIsg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.2.tgz",
+			"integrity": "sha512-Jyvqx691Z/pKi26UPk1WjUDwQMc0tJ6jit2dz8WysUXhWpkha4cwYXHPrmPTfBO2VHKGqjjN2MjzomdijPmkBg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -7145,12 +7104,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.1.tgz",
-			"integrity": "sha512-jyx9QtxJleK2vXi8HL0Fg0a83E/LLoyGT7sWKbnjRQ8b193ExAkzBIkHACCyADDsgLysVuH3esBAHdWsEqTIsg==",
+			"version": "npm:@fluidframework/tool-utils@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.2.tgz",
+			"integrity": "sha512-Jyvqx691Z/pKi26UPk1WjUDwQMc0tJ6jit2dz8WysUXhWpkha4cwYXHPrmPTfBO2VHKGqjjN2MjzomdijPmkBg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.2",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -7186,23 +7145,23 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.1.tgz",
-			"integrity": "sha512-yzxNEAFVIVPFUh+mdasTtLGbcNN7s8IzneabWCpaNe78a9CzSUaPyIE/QMQkc48jpVEPxfjbe+E2KUJlT2SX3Q==",
+			"version": "npm:@fluidframework/undo-redo@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.2.tgz",
+			"integrity": "sha512-0F5bXT23ZQfnD5JUYq+14i9ECvykDBRd1Px+wlrdM/LCYWu5gF64r73icM2Iwo0B6AVsrZh2TrC+qHCKzQ8r2g==",
 			"requires": {
-				"@fluidframework/map": "^1.2.1",
-				"@fluidframework/matrix": "^1.2.1",
-				"@fluidframework/merge-tree": "^1.2.1",
-				"@fluidframework/sequence": "^1.2.1"
+				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/matrix": "^1.2.2",
+				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/sequence": "^1.2.2"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.1.tgz",
-			"integrity": "sha512-I0NDsMv7f5zHUoL6qbENiZer+LwJ0dBnx/SO3oyBG5XqqJwHvdqOya9eC2K1A2uznO8KwurrV9xltXWLswsaZA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.2.tgz",
+			"integrity": "sha512-IsxVRVrIgP0w7JIJVn5VPwwtINhX/ZTCb2/h7BP2dXZRQpUHyvLM+mTkKMOAUf2TCaI4lh0RPk24Rbt9mauMjg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/view-interfaces": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/view-interfaces": "^1.2.2",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			},
@@ -7231,12 +7190,12 @@
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.1.tgz",
-			"integrity": "sha512-I0NDsMv7f5zHUoL6qbENiZer+LwJ0dBnx/SO3oyBG5XqqJwHvdqOya9eC2K1A2uznO8KwurrV9xltXWLswsaZA==",
+			"version": "npm:@fluidframework/view-adapters@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.2.tgz",
+			"integrity": "sha512-IsxVRVrIgP0w7JIJVn5VPwwtINhX/ZTCb2/h7BP2dXZRQpUHyvLM+mTkKMOAUf2TCaI4lh0RPk24Rbt9mauMjg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1",
-				"@fluidframework/view-interfaces": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/view-interfaces": "^1.2.2",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			},
@@ -7265,38 +7224,38 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.1.tgz",
-			"integrity": "sha512-twZlmk9dHffYvZDMq7uJPRw4wjH35XbsWe5ssEtQanYTeNfqXATb1LXcpJOiOLJD0xtGYD0QgdoBWhglYJhbcQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.2.tgz",
+			"integrity": "sha512-U0U4gObYIUmDHc8k/S2VuxI/BSHXCAD55Nc6MPOz17CP+XReOd8e0lrXF9aQoEV7m6xFXxUdXZhdipmiU8vsTA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1"
+				"@fluidframework/core-interfaces": "^1.2.2"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.1.tgz",
-			"integrity": "sha512-twZlmk9dHffYvZDMq7uJPRw4wjH35XbsWe5ssEtQanYTeNfqXATb1LXcpJOiOLJD0xtGYD0QgdoBWhglYJhbcQ==",
+			"version": "npm:@fluidframework/view-interfaces@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.2.tgz",
+			"integrity": "sha512-U0U4gObYIUmDHc8k/S2VuxI/BSHXCAD55Nc6MPOz17CP+XReOd8e0lrXF9aQoEV7m6xFXxUdXZhdipmiU8vsTA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.1"
+				"@fluidframework/core-interfaces": "^1.2.2"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.1.tgz",
-			"integrity": "sha512-m9UHWK+wjo0ciT1uFe42HSQm/Pa8kqB5Z5o4uFn8TcOJJZxc/mWA4/vy74/jkwn2kuMUmPh4g0YQmeNv7L9ZkA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.2.tgz",
+			"integrity": "sha512-+uE553TVW1ZoSRwMUosxb07x0Zk9yAKkJdwO8gQMY/Kkcg8hxjYR7wsTNwGdAQStzQxu/bfJDgbobmahZene6g==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.2.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.1.tgz",
-			"integrity": "sha512-m9UHWK+wjo0ciT1uFe42HSQm/Pa8kqB5Z5o4uFn8TcOJJZxc/mWA4/vy74/jkwn2kuMUmPh4g0YQmeNv7L9ZkA==",
+			"version": "npm:@fluidframework/web-code-loader@1.2.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.2.tgz",
+			"integrity": "sha512-+uE553TVW1ZoSRwMUosxb07x0Zk9yAKkJdwO8gQMY/Kkcg8hxjYR7wsTNwGdAQStzQxu/bfJDgbobmahZene6g==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.2",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -14847,15 +14806,15 @@
 			}
 		},
 		"@material-ui/core": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
-			"integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
+			"version": "4.12.4",
+			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
+			"integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@material-ui/styles": "^4.11.4",
-				"@material-ui/system": "^4.12.1",
+				"@material-ui/styles": "^4.11.5",
+				"@material-ui/system": "^4.12.2",
 				"@material-ui/types": "5.1.0",
-				"@material-ui/utils": "^4.11.2",
+				"@material-ui/utils": "^4.11.3",
 				"@types/react-transition-group": "^4.2.0",
 				"clsx": "^1.0.4",
 				"hoist-non-react-statics": "^3.3.2",
@@ -14866,26 +14825,26 @@
 			}
 		},
 		"@material-ui/lab": {
-			"version": "4.0.0-alpha.60",
-			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz",
-			"integrity": "sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==",
+			"version": "4.0.0-alpha.61",
+			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+			"integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@material-ui/utils": "^4.11.2",
+				"@material-ui/utils": "^4.11.3",
 				"clsx": "^1.0.4",
 				"prop-types": "^15.7.2",
 				"react-is": "^16.8.0 || ^17.0.0"
 			}
 		},
 		"@material-ui/styles": {
-			"version": "4.11.4",
-			"resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
-			"integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
+			"version": "4.11.5",
+			"resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+			"integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@emotion/hash": "^0.8.0",
 				"@material-ui/types": "5.1.0",
-				"@material-ui/utils": "^4.11.2",
+				"@material-ui/utils": "^4.11.3",
 				"clsx": "^1.0.4",
 				"csstype": "^2.5.2",
 				"hoist-non-react-statics": "^3.3.2",
@@ -14901,12 +14860,12 @@
 			}
 		},
 		"@material-ui/system": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
-			"integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+			"integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@material-ui/utils": "^4.11.2",
+				"@material-ui/utils": "^4.11.3",
 				"csstype": "^2.5.2",
 				"prop-types": "^15.7.2"
 			}
@@ -14917,9 +14876,9 @@
 			"integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
 		},
 		"@material-ui/utils": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-			"integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+			"integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"prop-types": "^15.7.2",
@@ -21398,9 +21357,9 @@
 			}
 		},
 		"@types/react-transition-group": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
-			"integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -22610,33 +22569,6 @@
 				"symbol.prototype.description": "^1.0.0"
 			}
 		},
-		"airbnb-prop-types": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-			"integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-			"requires": {
-				"array.prototype.find": "^2.1.1",
-				"function.prototype.name": "^1.1.2",
-				"is-regex": "^1.1.0",
-				"object-is": "^1.1.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.2",
-				"prop-types": "^15.7.2",
-				"prop-types-exact": "^1.2.0",
-				"react-is": "^16.13.1"
-			},
-			"dependencies": {
-				"is-regex": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-tostringtag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"ajv": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
@@ -23042,131 +22974,6 @@
 				"es-abstract": "^1.19.0",
 				"es-array-method-boxes-properly": "^1.0.0",
 				"is-string": "^1.0.7"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.20.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-					"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"function.prototype.name": "^1.1.5",
-						"get-intrinsic": "^1.1.1",
-						"get-symbol-description": "^1.0.0",
-						"has": "^1.0.3",
-						"has-property-descriptors": "^1.0.0",
-						"has-symbols": "^1.0.3",
-						"internal-slot": "^1.0.3",
-						"is-callable": "^1.2.4",
-						"is-negative-zero": "^2.0.2",
-						"is-regex": "^1.1.4",
-						"is-shared-array-buffer": "^1.0.2",
-						"is-string": "^1.0.7",
-						"is-weakref": "^1.0.2",
-						"object-inspect": "^1.12.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"regexp.prototype.flags": "^1.4.3",
-						"string.prototype.trimend": "^1.0.5",
-						"string.prototype.trimstart": "^1.0.5",
-						"unbox-primitive": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-					"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-				},
-				"is-callable": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
-				},
-				"is-negative-zero": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-					"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
-				},
-				"is-regex": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-tostringtag": "^1.0.0"
-					}
-				},
-				"object-inspect": {
-					"version": "1.12.2",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-					"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-					"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.4",
-						"es-abstract": "^1.19.5"
-					},
-					"dependencies": {
-						"define-properties": {
-							"version": "1.1.4",
-							"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-							"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-							"requires": {
-								"has-property-descriptors": "^1.0.0",
-								"object-keys": "^1.1.1"
-							}
-						}
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-					"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.4",
-						"es-abstract": "^1.19.5"
-					},
-					"dependencies": {
-						"define-properties": {
-							"version": "1.1.4",
-							"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-							"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-							"requires": {
-								"has-property-descriptors": "^1.0.0",
-								"object-keys": "^1.1.1"
-							}
-						}
-					}
-				}
-			}
-		},
-		"array.prototype.find": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-			"integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.4",
-				"es-shim-unscopables": "^1.0.0"
 			},
 			"dependencies": {
 				"es-abstract": {
@@ -23793,7 +23600,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -24427,22 +24234,29 @@
 			}
 		},
 		"babel-plugin-emotion": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-			"integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+			"version": "9.2.11",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+			"integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
-				"@emotion/hash": "0.8.0",
-				"@emotion/memoize": "0.7.4",
-				"@emotion/serialize": "^0.11.16",
+				"@emotion/babel-utils": "^0.6.4",
+				"@emotion/hash": "^0.6.2",
+				"@emotion/memoize": "^0.6.1",
+				"@emotion/stylis": "^0.7.0",
 				"babel-plugin-macros": "^2.0.0",
 				"babel-plugin-syntax-jsx": "^6.18.0",
 				"convert-source-map": "^1.5.0",
-				"escape-string-regexp": "^1.0.5",
 				"find-root": "^1.1.0",
-				"source-map": "^0.5.7"
+				"mkdirp": "^0.5.1",
+				"source-map": "^0.5.7",
+				"touch": "^2.0.1"
 			},
 			"dependencies": {
+				"@emotion/hash": {
+					"version": "0.6.6",
+					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+					"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+				},
 				"babel-plugin-macros": {
 					"version": "2.8.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -24484,7 +24298,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
 				}
 			}
 		},
@@ -28081,14 +27895,24 @@
 			}
 		},
 		"create-emotion": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
-			"integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+			"version": "9.2.12",
+			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+			"integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
 			"requires": {
-				"@emotion/cache": "^10.0.27",
-				"@emotion/serialize": "^0.11.15",
-				"@emotion/sheet": "0.9.4",
-				"@emotion/utils": "0.11.3"
+				"@emotion/hash": "^0.6.2",
+				"@emotion/memoize": "^0.6.1",
+				"@emotion/stylis": "^0.7.0",
+				"@emotion/unitless": "^0.6.2",
+				"csstype": "^2.5.2",
+				"stylis": "^3.5.0",
+				"stylis-rule-sheet": "^0.0.10"
+			},
+			"dependencies": {
+				"@emotion/hash": {
+					"version": "0.6.6",
+					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+					"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+				}
 			}
 		},
 		"create-error-class": {
@@ -29702,12 +29526,12 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
 		},
 		"emotion": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-			"integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+			"version": "9.2.12",
+			"resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
+			"integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
 			"requires": {
-				"babel-plugin-emotion": "^10.0.27",
-				"create-emotion": "^10.0.27"
+				"babel-plugin-emotion": "^9.2.11",
+				"create-emotion": "^9.2.12"
 			}
 		},
 		"empty-dir": {
@@ -31785,15 +31609,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.2.1",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.1.tgz",
-			"integrity": "sha512-VYO1WyD80hn/i3cfctKmugigbTeXhE2/DRQMxbNYshLHryWxLPsyZLcZlfWRp/9Zn3m3Vm7RZJBCK/9r6y7+eg==",
+			"version": "npm:fluid-framework@1.2.2",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.2.tgz",
+			"integrity": "sha512-1N7hGFrxflAP5ghPEus1o3mSy4sf3N/IbbF7C5KStxVI/+v0FzVSPUDA45TkiYD8f0JnK+NYfrYLII+PBBWHgw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.1",
-				"@fluidframework/container-loader": "^1.2.1",
-				"@fluidframework/fluid-static": "^1.2.1",
-				"@fluidframework/map": "^1.2.1",
-				"@fluidframework/sequence": "^1.2.1"
+				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-loader": "^1.2.2",
+				"@fluidframework/fluid-static": "^1.2.2",
+				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/sequence": "^1.2.2"
 			}
 		},
 		"flush-write-stream": {
@@ -41910,6 +41734,14 @@
 				"readable-stream": "~1.0.31"
 			}
 		},
+		"nopt": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+			"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+			"requires": {
+				"abbrev": "1"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -45877,16 +45709,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"prop-types-exact": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-			"integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-			"requires": {
-				"has": "^1.0.3",
-				"object.assign": "^4.1.0",
-				"reflect.ownkeys": "^0.2.0"
-			}
-		},
 		"propagate": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
@@ -46446,16 +46268,16 @@
 			}
 		},
 		"react-base-table": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/react-base-table/-/react-base-table-1.0.2.tgz",
-			"integrity": "sha512-9VSjoce9TsTxrMmPNgKnug64snYWzFMPgqMZUvQzlPs8o6RyechlixOMKKnNDaSrjRH8QEpvX9OThYfVKw/q6Q==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/react-base-table/-/react-base-table-1.13.2.tgz",
+			"integrity": "sha512-VhyKXZwEu8U/wH2eY3Ie3GJbvGP9wQzts26k1t/A7b8IS1OM31j8ul6HAvLmudpT33XqFPD7/KK18tfx/5I/eA==",
 			"requires": {
+				"@babel/runtime": "^7.0.0",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.5",
 				"memoize-one": "^5.0.0",
-				"prop-types": "^15.6.0",
-				"react-draggable": "^3.0.5",
-				"react-virtualized": "^9.18.5"
+				"prop-types": "^15.7.0",
+				"react-virtualized-auto-sizer": "^1.0.2",
+				"react-window": "^1.8.2"
 			}
 		},
 		"react-collapsible": {
@@ -46511,15 +46333,6 @@
 						"object-assign": "^4.1.1"
 					}
 				}
-			}
-		},
-		"react-draggable": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
-			"integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
-			"requires": {
-				"classnames": "^2.2.5",
-				"prop-types": "^15.6.0"
 			}
 		},
 		"react-element-to-jsx-string": {
@@ -46596,12 +46409,9 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-loading-skeleton": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-1.3.0.tgz",
-			"integrity": "sha512-uB4Re8QLOS5hauTdssWxvTXVBevygCDPWngjsbTVBRQVn14hKoB9OMX/KjU5ccuXtrPbwvQPUwylon/dYFf5bQ==",
-			"requires": {
-				"emotion": "^10.0.17"
-			}
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+			"integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw=="
 		},
 		"react-refresh": {
 			"version": "0.11.0",
@@ -46642,81 +46452,6 @@
 				"react-transition-group": "^2.2.1"
 			},
 			"dependencies": {
-				"@emotion/hash": {
-					"version": "0.6.6",
-					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-					"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
-				},
-				"@emotion/memoize": {
-					"version": "0.6.6",
-					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-					"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-				},
-				"@emotion/stylis": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-					"integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
-				},
-				"@emotion/unitless": {
-					"version": "0.6.7",
-					"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-					"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
-				},
-				"babel-plugin-emotion": {
-					"version": "9.2.11",
-					"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
-					"integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@emotion/babel-utils": "^0.6.4",
-						"@emotion/hash": "^0.6.2",
-						"@emotion/memoize": "^0.6.1",
-						"@emotion/stylis": "^0.7.0",
-						"babel-plugin-macros": "^2.0.0",
-						"babel-plugin-syntax-jsx": "^6.18.0",
-						"convert-source-map": "^1.5.0",
-						"find-root": "^1.1.0",
-						"mkdirp": "^0.5.1",
-						"source-map": "^0.5.7",
-						"touch": "^2.0.1"
-					}
-				},
-				"babel-plugin-macros": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-					"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-					"requires": {
-						"@babel/runtime": "^7.7.2",
-						"cosmiconfig": "^6.0.0",
-						"resolve": "^1.12.0"
-					}
-				},
-				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
-					}
-				},
-				"create-emotion": {
-					"version": "9.2.12",
-					"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
-					"integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
-					"requires": {
-						"@emotion/hash": "^0.6.2",
-						"@emotion/memoize": "^0.6.1",
-						"@emotion/stylis": "^0.7.0",
-						"@emotion/unitless": "^0.6.2",
-						"csstype": "^2.5.2",
-						"stylis": "^3.5.0",
-						"stylis-rule-sheet": "^0.0.10"
-					}
-				},
 				"dom-helpers": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
@@ -46724,31 +46459,6 @@
 					"requires": {
 						"@babel/runtime": "^7.1.2"
 					}
-				},
-				"emotion": {
-					"version": "9.2.12",
-					"resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
-					"integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
-					"requires": {
-						"babel-plugin-emotion": "^9.2.11",
-						"create-emotion": "^9.2.12"
-					}
-				},
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				},
 				"react-transition-group": {
 					"version": "2.9.0",
@@ -46760,11 +46470,6 @@
 						"prop-types": "^15.6.2",
 						"react-lifecycles-compat": "^3.0.4"
 					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -46809,23 +46514,19 @@
 				"prop-types": "^15.6.2"
 			}
 		},
-		"react-virtualized": {
-			"version": "9.22.3",
-			"resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-			"integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-			"requires": {
-				"@babel/runtime": "^7.7.2",
-				"clsx": "^1.0.4",
-				"dom-helpers": "^5.1.3",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.7.2",
-				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
 		"react-virtualized-auto-sizer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
 			"integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ=="
+		},
+		"react-window": {
+			"version": "1.8.7",
+			"resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.7.tgz",
+			"integrity": "sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==",
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"memoize-one": ">=3.1.1 <6"
+			}
 		},
 		"read": {
 			"version": "1.0.7",
@@ -47156,11 +46857,6 @@
 			"requires": {
 				"redis-errors": "^1.0.0"
 			}
-		},
-		"reflect.ownkeys": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-			"integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
 		},
 		"refractor": {
 			"version": "3.6.0",
@@ -48651,7 +48347,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
 		},
 		"setprototypeof": {
 			"version": "1.2.0",
@@ -51949,16 +51645,6 @@
 			"integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
 			"requires": {
 				"nopt": "~1.0.10"
-			},
-			"dependencies": {
-				"nopt": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-					"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-					"requires": {
-						"abbrev": "1"
-					}
-				}
 			}
 		},
 		"tough-cookie": {
@@ -54708,7 +54394,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"worker-farm": {
 			"version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3200,7 +3200,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
 		"assert": {
@@ -9805,7 +9805,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true
 		},
 		"shallow-clone": {
@@ -10824,7 +10824,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"wrap-ansi": {


### PR DESCRIPTION

- Update[ react-base-table ](https://github.com/Autodesk/react-base-table) to latest version 
- Fix small breaking changes 

Benefits: 
- React 17 support 
- Smaller bundle size 
- Better table performance 